### PR TITLE
[feature] 루틴 완료 업데이트

### DIFF
--- a/src/main/java/com/rememberme/dunoesanchaeg/contents/service/CognitiveGameServiceImpl.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/contents/service/CognitiveGameServiceImpl.java
@@ -91,7 +91,7 @@ public class CognitiveGameServiceImpl implements CognitiveGameService {
         routineMapper.updateGameComplete(routine.getRoutineId());
 
         // 희주님 루틴 업데이트 구현되면 넣기
-        // routineService.completeRoutineItem(memberId, "GAME");
+        routineService.completeRoutineItem(memberId, "GAME");
 
         return GameFinishedResponse.builder()
                 .correctCount(request.getCorrectCount())

--- a/src/main/java/com/rememberme/dunoesanchaeg/contents/service/CognitiveGameServiceImpl.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/contents/service/CognitiveGameServiceImpl.java
@@ -7,6 +7,7 @@ import com.rememberme.dunoesanchaeg.contents.dto.response.GameFinishedResponse;
 import com.rememberme.dunoesanchaeg.contents.dto.response.TodayGameResponse;
 import com.rememberme.dunoesanchaeg.contents.mapper.CognitiveGameMapper;
 import com.rememberme.dunoesanchaeg.routines.domain.DailyRoutineStatus;
+import com.rememberme.dunoesanchaeg.routines.domain.enums.MissionTypes;
 import com.rememberme.dunoesanchaeg.routines.mapper.RoutineMapper;
 import com.rememberme.dunoesanchaeg.routines.service.RoutineService;
 import lombok.RequiredArgsConstructor;
@@ -91,7 +92,7 @@ public class CognitiveGameServiceImpl implements CognitiveGameService {
         routineMapper.updateGameComplete(routine.getRoutineId());
 
         // 희주님 루틴 업데이트 구현되면 넣기
-        routineService.completeRoutineItem(memberId, "GAME");
+        routineService.completeRoutineItem(memberId, MissionTypes.GAME);
 
         return GameFinishedResponse.builder()
                 .correctCount(request.getCorrectCount())

--- a/src/main/java/com/rememberme/dunoesanchaeg/member/mapper/MemberMapper.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/member/mapper/MemberMapper.java
@@ -30,4 +30,7 @@ public interface MemberMapper {
 
     // 멤버 추가 프로필 업데이트
     int updateProfile(Member member);
+
+    // total_routine_count + 1 업데이트
+    int incrementTotalRoutineCount(@Param("memberId") Long memberId );
 }

--- a/src/main/java/com/rememberme/dunoesanchaeg/memory/service/DailyRecordServiceImpl.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/memory/service/DailyRecordServiceImpl.java
@@ -6,6 +6,7 @@ import com.rememberme.dunoesanchaeg.memory.dto.request.DailyRecordSaveRequest;
 import com.rememberme.dunoesanchaeg.memory.dto.response.DailyRecordResponse;
 import com.rememberme.dunoesanchaeg.memory.dto.response.DailyRecordSaveResponse;
 import com.rememberme.dunoesanchaeg.memory.mapper.DailyRecordMapper;
+import com.rememberme.dunoesanchaeg.routines.domain.enums.MissionTypes;
 import com.rememberme.dunoesanchaeg.routines.service.RoutineService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -58,7 +59,7 @@ public class DailyRecordServiceImpl implements DailyRecordService {
             }
         }
 
-        routineService.completeRoutineItem(memberId, "RECORD");
+        routineService.completeRoutineItem(memberId, MissionTypes.RECORD);
 
         return new DailyRecordSaveResponse(
                 today,

--- a/src/main/java/com/rememberme/dunoesanchaeg/memory/service/DailyRecordServiceImpl.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/memory/service/DailyRecordServiceImpl.java
@@ -58,7 +58,7 @@ public class DailyRecordServiceImpl implements DailyRecordService {
             }
         }
 
-        // routineService.completeRoutineItem(memberId, "RECORD");
+        routineService.completeRoutineItem(memberId, "RECORD");
 
         return new DailyRecordSaveResponse(
                 today,

--- a/src/main/java/com/rememberme/dunoesanchaeg/memory/service/OpenQuestionRoutineServiceImpl.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/memory/service/OpenQuestionRoutineServiceImpl.java
@@ -124,6 +124,8 @@ public class OpenQuestionRoutineServiceImpl implements OpenQuestionRoutineServic
 
         dailyQuestionLogService.updateTodayQuestionLog(dailyQuestionLog);
 
+        routineService.completeRoutineItem(memberId, "QUESTION");
+
         return new OpenQuestionCompleteResponse(dailyQuestionLogId, DailyQuestionLogStatus.COMPLETED);
     }
 }

--- a/src/main/java/com/rememberme/dunoesanchaeg/memory/service/OpenQuestionRoutineServiceImpl.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/memory/service/OpenQuestionRoutineServiceImpl.java
@@ -7,6 +7,7 @@ import com.rememberme.dunoesanchaeg.memory.domain.enums.DailyQuestionLogStatus;
 import com.rememberme.dunoesanchaeg.memory.dto.response.OpenQuestionCompleteResponse;
 import com.rememberme.dunoesanchaeg.memory.dto.response.OpenQuestionExitResponse;
 import com.rememberme.dunoesanchaeg.memory.dto.response.OpenQuestionStartResponse;
+import com.rememberme.dunoesanchaeg.routines.domain.enums.MissionTypes;
 import com.rememberme.dunoesanchaeg.routines.service.RoutineService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DuplicateKeyException;
@@ -124,7 +125,7 @@ public class OpenQuestionRoutineServiceImpl implements OpenQuestionRoutineServic
 
         dailyQuestionLogService.updateTodayQuestionLog(dailyQuestionLog);
 
-        routineService.completeRoutineItem(memberId, "QUESTION");
+        routineService.completeRoutineItem(memberId, MissionTypes.QUESTION);
 
         return new OpenQuestionCompleteResponse(dailyQuestionLogId, DailyQuestionLogStatus.COMPLETED);
     }

--- a/src/main/java/com/rememberme/dunoesanchaeg/routines/domain/DailyRoutineStatus.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/routines/domain/DailyRoutineStatus.java
@@ -1,6 +1,7 @@
 package com.rememberme.dunoesanchaeg.routines.domain;
 
 import com.rememberme.dunoesanchaeg.routines.domain.enums.AssignedGameType;
+import com.rememberme.dunoesanchaeg.routines.domain.enums.MissionTypes;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class DailyRoutineStatus {
+    private MissionTypes missionTypes; // GAME, RECORD, QUESTION
 
     private Long routineId;
     private Long memberId;

--- a/src/main/java/com/rememberme/dunoesanchaeg/routines/domain/enums/MissionTypes.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/routines/domain/enums/MissionTypes.java
@@ -1,0 +1,7 @@
+package com.rememberme.dunoesanchaeg.routines.domain.enums;
+
+public enum MissionTypes {
+    GAME,
+    RECORD,
+    QUESTION
+}

--- a/src/main/java/com/rememberme/dunoesanchaeg/routines/dto/response/RoutineResponse.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/routines/dto/response/RoutineResponse.java
@@ -1,6 +1,7 @@
 package com.rememberme.dunoesanchaeg.routines.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.rememberme.dunoesanchaeg.routines.domain.enums.MissionTypes;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +15,8 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class RoutineResponse {
+
+    private MissionTypes missionTypes; // GAME, RECORD, QUESTION
 
     private Long routineId;
 

--- a/src/main/java/com/rememberme/dunoesanchaeg/routines/mapper/RoutineMapper.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/routines/mapper/RoutineMapper.java
@@ -16,8 +16,17 @@ public interface RoutineMapper {
     // 오늘의 루틴 삽입
     int insertTodayRoutine(DailyRoutineStatus routine);
 
-    // 오늘의 루틴 업데이트
-    void updateTodayRoutine(DailyRoutineStatus routine);
+    // 루틴 아이디로 오늘의 루틴 조회
+    DailyRoutineStatus findByRoutineId(@Param("routineId") Long routineId);
+
+    // 오늘의 루틴 게임 완료 업데이트
+    int updateGameComplete(@Param("routineId") Long routineId);
+
+    // 오늘의 루틴 기록 완료 업데이트
+    int updateRecordComplete(@Param("routineId")Long routineId);
+
+    // 오늘의 루틴 질문 완료 업데이트
+    int updateQuestionComplete(@Param("routineId")Long routineId);
 
     // 개방형질문 기능 구현에 필요한 코드
     Long selectAssignedQuestionId(@Param("memberId") Long memberId, @Param("routineDate") LocalDate routineDate);

--- a/src/main/java/com/rememberme/dunoesanchaeg/routines/service/RoutineService.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/routines/service/RoutineService.java
@@ -6,8 +6,15 @@ import java.time.LocalDate;
 
 public interface RoutineService {
 
+    // 오늘의 루틴 조회
     RoutineResponse getTodayRoutine(Long memberId);
 
     // 개방형질문 기능 구현에 필요한 코드
     Long getAssignedQuestionId(Long memberId, LocalDate routineDate);
+
+    // GAME, RECORD, QUESTION 완료 업데이트
+    void completeRoutineItem(Long memberId, String type);
+
+    // totalRoutineCount 계산 (트로피 연결)
+    void totalRoutineCount(Long memberId);
 }

--- a/src/main/java/com/rememberme/dunoesanchaeg/routines/service/RoutineService.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/routines/service/RoutineService.java
@@ -1,5 +1,6 @@
 package com.rememberme.dunoesanchaeg.routines.service;
 
+import com.rememberme.dunoesanchaeg.routines.domain.enums.MissionTypes;
 import com.rememberme.dunoesanchaeg.routines.dto.response.RoutineResponse;
 
 import java.time.LocalDate;
@@ -13,7 +14,7 @@ public interface RoutineService {
     Long getAssignedQuestionId(Long memberId, LocalDate routineDate);
 
     // GAME, RECORD, QUESTION 완료 업데이트
-    void completeRoutineItem(Long memberId, String type);
+    void completeRoutineItem(Long memberId, MissionTypes missionTypes);
 
     // totalRoutineCount 계산 (트로피 연결)
     void totalRoutineCount(Long memberId);

--- a/src/main/java/com/rememberme/dunoesanchaeg/routines/service/RoutineServiceImpl.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/routines/service/RoutineServiceImpl.java
@@ -4,6 +4,7 @@ import com.rememberme.dunoesanchaeg.common.exception.BaseException;
 import com.rememberme.dunoesanchaeg.member.mapper.MemberMapper;
 import com.rememberme.dunoesanchaeg.routines.domain.DailyRoutineStatus;
 import com.rememberme.dunoesanchaeg.routines.domain.enums.AssignedGameType;
+import com.rememberme.dunoesanchaeg.routines.domain.enums.MissionTypes;
 import com.rememberme.dunoesanchaeg.routines.dto.response.RoutineResponse;
 import com.rememberme.dunoesanchaeg.routines.mapper.RoutineMapper;
 import com.rememberme.dunoesanchaeg.trophies.service.TrophyService;
@@ -75,9 +76,11 @@ public class RoutineServiceImpl implements RoutineService {
     // GAME, RECORD, QUESTION 완료로 업데이트
     @Override
     @Transactional(propagation = Propagation.REQUIRED)
-    public void completeRoutineItem(Long memberId, String type) {
+    public void completeRoutineItem(Long memberId, MissionTypes missionTypes) {
         // 타입 검증
-        String validatedType = validateType(type);
+        if (missionTypes == null) {
+            throw new BaseException(400, "루틴 타입이 필요합니다.");
+        }
 
         LocalDate today = LocalDate.now();
         DailyRoutineStatus routine = routineMapper.findByMemberIdAndDate(memberId, today);
@@ -87,7 +90,7 @@ public class RoutineServiceImpl implements RoutineService {
         }
 
         // 1. GAME, RECORD, QUESTION -> TRUE로 업데이트
-        int updateResult = processUpdate(routine, validatedType);
+        int updateResult = processUpdate(routine, missionTypes);
 
         // 2. 항목이 처음으로 완료 처리된 경우에만 전체 완료 체크 진행
         if (updateResult == 1) {
@@ -101,33 +104,16 @@ public class RoutineServiceImpl implements RoutineService {
         }
     }
 
-    // 미션 타입 검증 (GAME, RECORD, QUESTION이 아닌 경우 예외 처리)
-    private String validateType(String type) {
-        if (type == null) {
-            throw new BaseException(400, "루틴 타입이 필요합니다.");
-        }
-
-        String upper = type.toUpperCase();
-
-        if (!upper.equals("GAME") &&
-                !upper.equals("RECORD") &&
-                !upper.equals("QUESTION")) {
-            throw new BaseException(400, "잘못된 루틴 타입입니다.");
-        }
-
-        return upper;
-    }
-
     // GAME, RECORD, QUESTION -> TRUE로 업데이트
-    private int processUpdate(DailyRoutineStatus routine, String type) {
-        return switch (type) {
-            case "GAME" -> Boolean.FALSE.equals(routine.getIsGameFinished()) ?
+    private int processUpdate(DailyRoutineStatus routine, MissionTypes missionTypes) {
+        return switch (missionTypes) {
+            case GAME -> Boolean.FALSE.equals(routine.getIsGameFinished()) ?
                     routineMapper.updateGameComplete(routine.getRoutineId()) : 0;
-            case "RECORD" -> Boolean.FALSE.equals(routine.getIsRecordFinished()) ?
+            case RECORD -> Boolean.FALSE.equals(routine.getIsRecordFinished()) ?
                     routineMapper.updateRecordComplete(routine.getRoutineId()) : 0;
-            case "QUESTION" -> Boolean.FALSE.equals(routine.getIsQuestionFinished()) ?
+            case QUESTION -> Boolean.FALSE.equals(routine.getIsQuestionFinished()) ?
                     routineMapper.updateQuestionComplete(routine.getRoutineId()) : 0;
-            default -> throw new BaseException(400, "잘못된 루틴 타입입니다: " + type);
+//            default -> throw new BaseException(400, "잘못된 루틴 타입입니다: " + missionTypes);
         };
     }
 

--- a/src/main/java/com/rememberme/dunoesanchaeg/routines/service/RoutineServiceImpl.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/routines/service/RoutineServiceImpl.java
@@ -1,82 +1,179 @@
 package com.rememberme.dunoesanchaeg.routines.service;
 
 import com.rememberme.dunoesanchaeg.common.exception.BaseException;
+import com.rememberme.dunoesanchaeg.member.mapper.MemberMapper;
 import com.rememberme.dunoesanchaeg.routines.domain.DailyRoutineStatus;
 import com.rememberme.dunoesanchaeg.routines.domain.enums.AssignedGameType;
 import com.rememberme.dunoesanchaeg.routines.dto.response.RoutineResponse;
 import com.rememberme.dunoesanchaeg.routines.mapper.RoutineMapper;
+import com.rememberme.dunoesanchaeg.trophies.service.TrophyService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Random;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RoutineServiceImpl implements RoutineService {
     private final RoutineMapper routineMapper;
+    private final MemberMapper memberMapper;
+    private final TrophyService trophyService;
+    private final Random random = new Random();
 
+    // 오늘의 루틴 조회
     @Override
+    @Transactional
     public RoutineResponse getTodayRoutine(Long memberId) {
 
-        // 인증 확인 -> memberId가 null인 경우 에러 처리
+        // 멤버 아이디가 존재하지 않는 경우
         if (memberId == null) {
             throw new BaseException(401, "인증 정보가 유효하지 않습니다.");
         }
 
         LocalDate today = LocalDate.now();
-
-        // 1. 오늘의 루틴 조회
         DailyRoutineStatus routine = routineMapper.findByMemberIdAndDate(memberId, today);
 
-        // 2. 없으면 생성 필요
+        // 오늘의 루틴이 없는 경우 생성
         if (routine == null) {
-            routine = createRoutine(memberId, today);
-
-
-            try {
-                int insertTodayRoutine = routineMapper.insertTodayRoutine(routine);
-
-                if(insertTodayRoutine != 1){
-                    throw new BaseException(500, "오늘의 루틴을 생성하는 과정에 에러가 발생했습니다");
-                }
-            } catch (DuplicateKeyException e) {
-                routine = routineMapper.findByMemberIdAndDate(memberId, today);
-
-                if (routine == null) {
-                    throw new BaseException(500, "오늘의 루틴 생성 중 충돌이 발생했습니다.");
-                }
-            } catch (Exception e) {
-                throw new BaseException(500, "에러가 발생했습니다.");
-            }
-
+            routine = handleConcurrentCreation(memberId, today);
         }
 
-        // 3. progressRate 구현
+        return buildResponse(routine);
+    }
+
+    // 루틴 생성 시 발생 가능한 중복 생성 방지
+    private DailyRoutineStatus handleConcurrentCreation(Long memberId, LocalDate today) {
+        // 루틴 생성
+        DailyRoutineStatus newRoutine = createRoutine(memberId, today);
+
+        try {
+            int result = routineMapper.insertTodayRoutine(newRoutine);
+            if (result != 1) {
+                throw new BaseException(500, "오늘의 루틴 생성 중 DB INSERT가 실패했습니다.");
+            }
+            return newRoutine;
+        } catch (DuplicateKeyException e) {
+            // 거의 동시에 요청이 들어와 이미 생성된 경우, 재조회하여 반환
+            DailyRoutineStatus existing = routineMapper.findByMemberIdAndDate(memberId, today);
+            if (existing == null) {
+                throw new BaseException(500, "루틴 생성 중 충돌이 발생했습니다.");
+            }
+            return existing;
+        } catch (Exception e) {
+            log.error("루틴 생성 중 서버 내부 오류 발생: {}", e.getMessage());
+            throw new BaseException(500, "루틴 생성 중 서버 내부 오류가 발생했습니다.");
+        }
+    }
+
+    // GAME, RECORD, QUESTION 완료로 업데이트
+    @Override
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void completeRoutineItem(Long memberId, String type) {
+        // 타입 검증
+        String validatedType = validateType(type);
+
+        LocalDate today = LocalDate.now();
+        DailyRoutineStatus routine = routineMapper.findByMemberIdAndDate(memberId, today);
+
+        if (routine == null) {
+            throw new BaseException(404, "오늘의 루틴 정보를 찾을 수 없습니다.");
+        }
+
+        // 1. GAME, RECORD, QUESTION -> TRUE로 업데이트
+        int updateResult = processUpdate(routine, validatedType);
+
+        // 2. 항목이 처음으로 완료 처리된 경우에만 전체 완료 체크 진행
+        if (updateResult == 1) {
+            // 업데이트된 최신 루틴 상태 조회
+            DailyRoutineStatus updatedRoutine = routineMapper.findByRoutineId(routine.getRoutineId());
+
+            // 3. 게임, 기록, 질문이 모두 TRUE인지 확인
+            if (isAllFinished(updatedRoutine)) {
+                this.totalRoutineCount(memberId);
+            }
+        }
+    }
+
+    // 미션 타입 검증 (GAME, RECORD, QUESTION이 아닌 경우 예외 처리)
+    private String validateType(String type) {
+        if (type == null) {
+            throw new BaseException(400, "루틴 타입이 필요합니다.");
+        }
+
+        String upper = type.toUpperCase();
+
+        if (!upper.equals("GAME") &&
+                !upper.equals("RECORD") &&
+                !upper.equals("QUESTION")) {
+            throw new BaseException(400, "잘못된 루틴 타입입니다.");
+        }
+
+        return upper;
+    }
+
+    // GAME, RECORD, QUESTION -> TRUE로 업데이트
+    private int processUpdate(DailyRoutineStatus routine, String type) {
+        return switch (type) {
+            case "GAME" -> Boolean.FALSE.equals(routine.getIsGameFinished()) ?
+                    routineMapper.updateGameComplete(routine.getRoutineId()) : 0;
+            case "RECORD" -> Boolean.FALSE.equals(routine.getIsRecordFinished()) ?
+                    routineMapper.updateRecordComplete(routine.getRoutineId()) : 0;
+            case "QUESTION" -> Boolean.FALSE.equals(routine.getIsQuestionFinished()) ?
+                    routineMapper.updateQuestionComplete(routine.getRoutineId()) : 0;
+            default -> throw new BaseException(400, "잘못된 루틴 타입입니다: " + type);
+        };
+    }
+
+    // 트로피를 위한 total_routine_count 계산
+    @Override
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void totalRoutineCount(Long memberId) {
+        // Member 테이블의 total_routine_count를 1 증가시킴
+        int affectedRows = memberMapper.incrementTotalRoutineCount(memberId);
+
+        // 트로피 로직에서 예외가 발생해도 루틴 완료는 유지되도록 예외 처리 고려 가능
+        if (affectedRows == 1) {
+            try {
+                trophyService.awardRoutineCountTrophy(memberId);
+            } catch (Exception e) {
+                log.error("트로피 수여 중 오류 발생: {}", e.getMessage());
+            }
+        }
+    }
+
+    // 미션이 모두 끝났는지 확인
+    private boolean isAllFinished(DailyRoutineStatus updatedRoutine) {
+        return Boolean.TRUE.equals(updatedRoutine.getIsGameFinished()) &&
+                Boolean.TRUE.equals(updatedRoutine.getIsRecordFinished()) &&
+                Boolean.TRUE.equals(updatedRoutine.getIsQuestionFinished());
+    }
+
+    // 조회 시 리턴할 응답
+    private RoutineResponse buildResponse(DailyRoutineStatus routine) {
+
         int completedCount = 0;
 
-        if (routine.getIsGameFinished()) completedCount++;
-        if (routine.getIsRecordFinished()) completedCount++;
-        if (routine.getIsQuestionFinished()) completedCount++;
+        if (Boolean.TRUE.equals(routine.getIsGameFinished())) completedCount++;
+        if (Boolean.TRUE.equals(routine.getIsRecordFinished())) completedCount++;
+        if (Boolean.TRUE.equals(routine.getIsQuestionFinished())) completedCount++;
 
         int progressRate = (int) ((completedCount / 3.0) * 100);
 
-        // completedCount에 따른 feedbackMessage
-        String feedbackMsg = "";
+        String feedbackMsg = switch (completedCount) {
+            case 0 -> "아직 루틴을 시작하지 않았어요. 함께 시작해볼까요?";
+            case 1 -> "조금만 더 힘내세요! 5분이면 충분합니다.";
+            case 2 -> "거의 다 왔어요! 하나만 더 하면 완벽해요!";
+            case 3 -> "오늘의 루틴을 모두 완료했어요. 수고했어요!";
+            default -> "";
+        };
 
-        if (completedCount == 0) {
-            feedbackMsg = "아직 루틴을 시작하지 않았어요. 함께 시작해볼까요?";
-        } else if (completedCount == 1) {
-            feedbackMsg = "조금만 더 힘내세요! 5분이면 충분합니다.";
-        } else if (completedCount == 2) {
-            feedbackMsg = "거의 다 왔어요! 하나만 더 하면 완벽해요!";
-        } else if (completedCount == 3){
-            feedbackMsg = "오늘의 루틴을 모두 완료했어요. 수고했어요!";
-        }
-
-        // 4. Dto 변환
         return RoutineResponse.builder()
                 .routineId(routine.getRoutineId())
                 .routineDate(routine.getRoutineDate())
@@ -92,7 +189,7 @@ public class RoutineServiceImpl implements RoutineService {
                 .build();
     }
 
-    // 루틴 생성
+    // 오늘의 루틴 조회 시 없다면 오늘의 루틴 생성
     private DailyRoutineStatus createRoutine(Long memberId, LocalDate today) {
         return DailyRoutineStatus.builder()
                 .memberId(memberId)
@@ -106,15 +203,16 @@ public class RoutineServiceImpl implements RoutineService {
                 .build();
     }
 
-    // 게임 랜덤 배정
+    // 랜덤 게임 부여
     private AssignedGameType randomGame() {
         AssignedGameType[] games = AssignedGameType.values();
-        return games[new Random().nextInt(games.length)];
+        return games[random.nextInt(games.length)];
     }
 
-    // 개방형 질문 랜덤 배정
+    // 랜덤 질문 부여
+    // ///////////////////////// 랜덤 질문 수는 아직 정해지지 않음 ...
     private Long randomQuestion() {
-        return (long) (new Random().nextInt(10) + 1);
+        return (long) (random.nextInt(10) + 1);
     }
 
     // 개방형질문 기능 구현에 필요한 코드

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -126,4 +126,11 @@
             updated_at = NOW()
         WHERE member_id = #{memberId}
     </update>
+
+    <!--  incrementTotalRoutineCount  -->
+    <update id="incrementTotalRoutineCount">
+        UPDATE member
+        SET total_routine_count = total_routine_count + 1
+        WHERE member_id = #{memberId}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/RoutineMapper.xml
+++ b/src/main/resources/mapper/RoutineMapper.xml
@@ -45,20 +45,35 @@
                  );
     </insert>
 
-    <update id="updateTodayRoutine">
-        UPDATE daily_routine_status
-        SET assigned_game_type = #{assignedGameType},
-            assigned_question_id = #{assignedQuestionId},
-            is_game_finished = #{isGameFinished},
-            is_record_finished = #{isRecordFinished},
-            is_question_finished = #{isQuestionFinished}
+    <!--  루틴 아이디로 조회하기  -->
+    <select id="findByRoutineId" resultMap="RoutineResultMap">
+        SELECT *
+        FROM daily_routine_status
         WHERE routine_id = #{routineId}
-    </update>
+    </select>
 
+    <!--  오늘의 루틴 게임 완료 업데이트  -->
     <update id="updateGameComplete">
         UPDATE daily_routine_status
         SET is_game_finished = true
         WHERE routine_id = #{routineId}
+        AND is_game_finished = false;
+    </update>
+
+    <!--  오늘의 루틴 기록 완료 업데이트  -->
+    <update id="updateRecordComplete">
+        UPDATE daily_routine_status
+        SET is_record_finished = true
+        WHERE routine_id = #{routineId}
+        AND is_record_finished = false;
+    </update>
+
+    <!--  오늘의 루틴 질문 완료 업데이트  -->
+    <update id="updateQuestionComplete">
+        UPDATE daily_routine_status
+        SET is_question_finished = true
+        WHERE routine_id = #{routineId}
+        AND is_question_finished = false;
     </update>
 
     <!-- 개방형질문 기능 구현에 필요한 코드 -->


### PR DESCRIPTION
[feature] 루틴 완료 업데이트
 
## 🔎개요 
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- 게임/기록/질문수행 완료 시 완료 업데이트
- 트로피 계산을 위한 코드 추가
 
 
<br/>
 
## 📝작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
 - 게임/기록/질문 수행 완료 시 완료 업데이트
   - (DB) is_game_finished, is_record_finished, is_question_finished 값을 true로 변경
   - 각 미션의 ServiceImpl 파일에서 RoutineServiceImpl 파일의 completeRoutineItem와 연결 코드 추가
- 트로피 계산을 위한 코드 추가
  - 게임/기록/질문이 모두 완료 되었을 시 member 테이블의 total_routine_count 를 +1 해줌
 

<br/>
 
 
## #️⃣관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
[feature] 루틴 완료 업데이트 #69
