### PR TITLE
[feat]calendar-completed-days

### DIFF
--- a/src/main/java/com/rememberme/dunoesanchaeg/calendar/controller/CalendarController.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/calendar/controller/CalendarController.java
@@ -1,10 +1,13 @@
 package com.rememberme.dunoesanchaeg.calendar.controller;
 
+import com.rememberme.dunoesanchaeg.calendar.dto.request.CalendarMonthRequest;
 import com.rememberme.dunoesanchaeg.calendar.dto.request.CalendarSummaryRequest;
+import com.rememberme.dunoesanchaeg.calendar.dto.response.CalendarMonthResponse;
 import com.rememberme.dunoesanchaeg.calendar.dto.response.CalendarSummaryResponse;
 import com.rememberme.dunoesanchaeg.calendar.service.CalendarSummaryService;
 import com.rememberme.dunoesanchaeg.common.ApiResponse;
 import com.rememberme.dunoesanchaeg.common.security.SecurityUtil;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,6 +34,24 @@ public class CalendarController {
 
 		return ResponseEntity.ok(
 				ApiResponse.success(200, "일간 종합 기록 조회를 성공했습니다.", response)
+		);
+	}
+
+	@Operation(
+			summary = "월간 루틴 완료 일자 조회",
+			description = "요청한 날짜가 속한 달에서 루틴을 1개라도 완료한 날짜 목록을 조회합니다."
+	)
+	@GetMapping("/completed-days")
+	public ResponseEntity<ApiResponse<CalendarMonthResponse>> getMonthlyCompletedRoutineDays(
+			@Valid @ModelAttribute CalendarMonthRequest request
+	) {
+		Long memberId = SecurityUtil.getCurrentMemberId();
+
+		CalendarMonthResponse response =
+				calendarSummaryService.getMonthlyCompletedRoutineDays(memberId, request);
+
+		return ResponseEntity.ok(
+				ApiResponse.success(200, "월간 루틴 완료 일자 조회를 성공했습니다.", response)
 		);
 	}
 }

--- a/src/main/java/com/rememberme/dunoesanchaeg/calendar/dto/request/CalendarMonthRequest.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/calendar/dto/request/CalendarMonthRequest.java
@@ -1,0 +1,32 @@
+package com.rememberme.dunoesanchaeg.calendar.dto.request;
+
+import com.rememberme.dunoesanchaeg.common.exception.BaseException;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CalendarMonthRequest {
+
+	@NotBlank(message = "필수 파라미터입니다. (YYYY-MM-DD 형식으로 입력해주세요.)")
+	@Pattern(
+			regexp = "^\\d{4}-\\d{2}-\\d{2}$",
+			message = "필수 파라미터입니다. (YYYY-MM-DD 형식으로 입력해주세요.)"
+	)
+	private String targetDate;
+
+	public LocalDate toLocalDate() {
+		try {
+			return LocalDate.parse(targetDate);
+		} catch (DateTimeParseException e) {
+			throw new BaseException(400, "잘못된 요청입니다. 입력값을 확인해주세요.");
+		}
+	}
+}

--- a/src/main/java/com/rememberme/dunoesanchaeg/calendar/dto/request/CalendarSummaryRequest.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/calendar/dto/request/CalendarSummaryRequest.java
@@ -17,7 +17,7 @@ public class CalendarSummaryRequest {
 
 	@NotBlank(message = "필수 파라미터입니다. (YYYY-MM-DD 형식으로 입력해주세요.)")
 	@Pattern(
-			regexp = "2026-03-31",
+			regexp = "^\\d{4}-\\d{2}-\\d{2}$",
 			message = "필수 파라미터입니다. (YYYY-MM-DD 형식으로 입력해주세요.)"
 	)
 	private String targetDate;

--- a/src/main/java/com/rememberme/dunoesanchaeg/calendar/dto/response/CalendarMonthResponse.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/calendar/dto/response/CalendarMonthResponse.java
@@ -1,0 +1,18 @@
+package com.rememberme.dunoesanchaeg.calendar.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CalendarMonthResponse {
+
+	@JsonProperty("target_month")
+	private String targetMonth;
+
+	@JsonProperty("completed_dates")
+	private List<String> completedDates;
+}

--- a/src/main/java/com/rememberme/dunoesanchaeg/calendar/mapper/CalendarSummaryMapper.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/calendar/mapper/CalendarSummaryMapper.java
@@ -7,6 +7,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Mapper
 public interface CalendarSummaryMapper {
@@ -24,5 +25,11 @@ public interface CalendarSummaryMapper {
 	DailyRecordDetail findDailyRecord(
 			@Param("memberId") Long memberId,
 			@Param("targetDate") LocalDate targetDate
+	);
+
+	List<LocalDate> findCompletedRoutineDates(
+			@Param("memberId") Long memberId,
+			@Param("startDate") LocalDate startDate,
+			@Param("endDate") LocalDate endDate
 	);
 }

--- a/src/main/java/com/rememberme/dunoesanchaeg/calendar/service/CalendarSummaryService.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/calendar/service/CalendarSummaryService.java
@@ -1,9 +1,13 @@
 package com.rememberme.dunoesanchaeg.calendar.service;
 
+import com.rememberme.dunoesanchaeg.calendar.dto.request.CalendarMonthRequest;
 import com.rememberme.dunoesanchaeg.calendar.dto.request.CalendarSummaryRequest;
+import com.rememberme.dunoesanchaeg.calendar.dto.response.CalendarMonthResponse;
 import com.rememberme.dunoesanchaeg.calendar.dto.response.CalendarSummaryResponse;
 
 public interface CalendarSummaryService {
 
 	CalendarSummaryResponse getCalendarSummary(Long memberId, CalendarSummaryRequest request);
+
+	CalendarMonthResponse getMonthlyCompletedRoutineDays(Long memberId, CalendarMonthRequest request);
 }

--- a/src/main/java/com/rememberme/dunoesanchaeg/calendar/service/CalendarSummaryServiceImpl.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/calendar/service/CalendarSummaryServiceImpl.java
@@ -1,6 +1,8 @@
 package com.rememberme.dunoesanchaeg.calendar.service;
 
+import com.rememberme.dunoesanchaeg.calendar.dto.request.CalendarMonthRequest;
 import com.rememberme.dunoesanchaeg.calendar.dto.request.CalendarSummaryRequest;
+import com.rememberme.dunoesanchaeg.calendar.dto.response.CalendarMonthResponse;
 import com.rememberme.dunoesanchaeg.calendar.dto.response.CalendarSummaryResponse;
 import com.rememberme.dunoesanchaeg.calendar.dto.response.DailyRecordDetail;
 import com.rememberme.dunoesanchaeg.calendar.dto.response.GameRecord;
@@ -13,7 +15,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.Arrays;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -59,6 +63,7 @@ public class CalendarSummaryServiceImpl implements CalendarSummaryService {
 				.dailyRecord(dailyRecord)
 				.build();
 	}
+
 	private int calculateProgressRate(Boolean... statuses) {
 		// 1. 방어 로직: 인자가 없거나 null인 경우 0% 반환
 		if (statuses == null || statuses.length == 0) {
@@ -72,6 +77,33 @@ public class CalendarSummaryServiceImpl implements CalendarSummaryService {
 
 		// 3. 계산 (이미 위에서 length == 0을 걸러냈으므로 안전합니다)
 		return (int) ((completedCount * 100) / statuses.length);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public CalendarMonthResponse getMonthlyCompletedRoutineDays(
+			Long memberId,
+			CalendarMonthRequest request
+	) {
+		validateMemberExists(memberId);
+
+		LocalDate targetDate = request.toLocalDate();
+		YearMonth targetMonth = YearMonth.from(targetDate);
+
+		LocalDate startDate = targetMonth.atDay(1);
+		LocalDate endDate = targetMonth.atEndOfMonth();
+
+		List<LocalDate> completedDates =
+				calendarSummaryMapper.findCompletedRoutineDates(memberId, startDate, endDate);
+
+		List<String> completedDateStrings = completedDates.stream()
+				.map(LocalDate::toString)
+				.toList();
+
+		return CalendarMonthResponse.builder()
+				.targetMonth(targetMonth.toString())
+				.completedDates(completedDateStrings)
+				.build();
 	}
 
 	private void validateMemberExists(Long memberId) {

--- a/src/main/resources/mapper/CalendarSummaryMapper.xml
+++ b/src/main/resources/mapper/CalendarSummaryMapper.xml
@@ -66,4 +66,17 @@
             LIMIT 1
     </select>
 
+    <select id="findCompletedRoutineDates" resultType="java.time.LocalDate">
+        SELECT DISTINCT routine_date
+        FROM daily_routine_status
+        WHERE member_id = #{memberId}
+          AND routine_date BETWEEN #{startDate} AND #{endDate}
+          AND (
+            is_game_finished = 1
+            OR is_record_finished = 1
+            OR is_question_finished = 1
+            )
+        ORDER BY routine_date ASC;
+    </select>
+
 </mapper>


### PR DESCRIPTION
[feat] calendar 한달 기준 루틴을 수행 한 날짜 조회
 
## 🔎개요 
타겟 날짜 기준 한달을 계산해 한달 내  루틴을 수행한 날짜만 리턴하는 api 구현 
 
 
<br/>

 
## 👀변경 사항
@Pattern 어노테이션에서 고정 방식에서 정규식으로 날짜를 요청 받을 수 있게 수정
 
 
<br/>
<img width="816" height="336" alt="image" src="https://github.com/user-attachments/assets/502a87c2-b827-4d21-bb2b-bee5c5663d01" />
