### PR TITLE
[refactor] 통계 그래프 scores 배열 추가

### DIFF
--- a/src/main/java/com/rememberme/dunoesanchaeg/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/statistics/controller/StatisticsController.java
@@ -19,19 +19,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class StatisticsController {
 
+    private final StatisticsService statisticsService;
 
-    private final StatisticsService StatisticsService;
-
-    @GetMapping("/games")
+    @GetMapping("/games/weekly-types")
     public ResponseEntity<ApiResponse<StatisticsResponse>> getWeeklyTypeStatistics(
-            @Valid @ModelAttribute StatisticsRequest request) {
-
+            @Valid @ModelAttribute StatisticsRequest request
+    ) {
         Long memberId = SecurityUtil.getCurrentMemberId();
 
-        StatisticsResponse response = StatisticsService.getStatistics(memberId, request);
+        StatisticsResponse response =
+                statisticsService.getWeeklyTypeStatistics(memberId, request);
 
         return ResponseEntity.ok(
-                ApiResponse.success(200, "종목별 최근 7회 플레이 종합 통계 조회를 성공했습니다.", response)
+                ApiResponse.success(200, "종목별 최근 7회 플레이 통계 조회를 성공했습니다.", response)
         );
     }
 }

--- a/src/main/java/com/rememberme/dunoesanchaeg/statistics/domain/RecentGameScore.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/statistics/domain/RecentGameScore.java
@@ -1,0 +1,14 @@
+package com.rememberme.dunoesanchaeg.statistics.domain;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RecentGameScore {
+
+	private Integer correctCount;
+}

--- a/src/main/java/com/rememberme/dunoesanchaeg/statistics/dto/request/StatisticsRequest.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/statistics/dto/request/StatisticsRequest.java
@@ -2,13 +2,20 @@ package com.rememberme.dunoesanchaeg.statistics.dto.request;
 
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
-@AllArgsConstructor
+@Setter
+@NoArgsConstructor
 public class StatisticsRequest {
 
     @NotBlank(message = "필수 파라미터입니다. (YYYY-MM-DD 형식으로 입력해주세요.)")
+    @Pattern(
+            regexp = "^\\d{4}-\\d{2}-\\d{2}$",
+            message = "필수 파라미터입니다. (YYYY-MM-DD 형식으로 입력해주세요.)"
+    )
     private String targetDate;
 }

--- a/src/main/java/com/rememberme/dunoesanchaeg/statistics/dto/response/StatisticsItemResponse.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/statistics/dto/response/StatisticsItemResponse.java
@@ -6,8 +6,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -30,4 +34,7 @@ public class StatisticsItemResponse {
 
     @JsonProperty("accuracy")
     private Integer accuracy;
+
+    @JsonProperty("scores")
+    private List<Integer> scores;
 }

--- a/src/main/java/com/rememberme/dunoesanchaeg/statistics/mapper/StatisticsMapper.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/statistics/mapper/StatisticsMapper.java
@@ -1,6 +1,7 @@
 package com.rememberme.dunoesanchaeg.statistics.mapper;
 
-import com.rememberme.dunoesanchaeg.statistics.dto.response.StatisticsItemResponse;
+import com.rememberme.dunoesanchaeg.statistics.domain.RecentGameScore;
+import com.rememberme.dunoesanchaeg.statistics.domain.enums.GameType;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -10,8 +11,9 @@ import java.util.List;
 @Mapper
 public interface StatisticsMapper {
 
-    List<StatisticsItemResponse> findStatistics(
+    List<RecentGameScore> findScoresByType(
             @Param("memberId") Long memberId,
+            @Param("gameType") GameType gameType,
             @Param("targetDate") LocalDate targetDate
     );
 }

--- a/src/main/java/com/rememberme/dunoesanchaeg/statistics/service/StatisticsService.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/statistics/service/StatisticsService.java
@@ -5,5 +5,5 @@ import com.rememberme.dunoesanchaeg.statistics.dto.response.StatisticsResponse;
 
 public interface StatisticsService {
 
-    StatisticsResponse getStatistics(Long memberId, StatisticsRequest request);
+    StatisticsResponse getWeeklyTypeStatistics(Long memberId, StatisticsRequest request);
 }

--- a/src/main/java/com/rememberme/dunoesanchaeg/statistics/service/StatisticsServiceImpl.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/statistics/service/StatisticsServiceImpl.java
@@ -1,8 +1,8 @@
 package com.rememberme.dunoesanchaeg.statistics.service;
 
 import com.rememberme.dunoesanchaeg.common.exception.BaseException;
-import com.rememberme.dunoesanchaeg.member.domain.Member;
 import com.rememberme.dunoesanchaeg.member.mapper.MemberMapper;
+import com.rememberme.dunoesanchaeg.statistics.domain.RecentGameScore;
 import com.rememberme.dunoesanchaeg.statistics.domain.enums.GameType;
 import com.rememberme.dunoesanchaeg.statistics.dto.request.StatisticsRequest;
 import com.rememberme.dunoesanchaeg.statistics.dto.response.StatisticsItemResponse;
@@ -13,40 +13,28 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
-import java.util.EnumMap;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class StatisticsServiceImpl implements StatisticsService {
 
-    private final StatisticsMapper StatisticsMapper;
+    private final StatisticsMapper statisticsMapper;
     private final MemberMapper memberMapper;
 
     @Override
     @Transactional(readOnly = true)
-    public StatisticsResponse getStatistics(Long memberId, StatisticsRequest request) {
+    public StatisticsResponse getWeeklyTypeStatistics(Long memberId, StatisticsRequest request) {
+        validateMemberExists(memberId);
 
-        validateMember(memberId);
-
-        LocalDate targetDate = parseTargetDate(request.getTargetDate());
-
-        validateNotFuture(targetDate);
-
-        List<StatisticsItemResponse> rawStats = StatisticsMapper.findStatistics(memberId, targetDate);
-
-        Map<GameType, StatisticsItemResponse> statMap = new EnumMap<>(GameType.class);
-
-        for (StatisticsItemResponse rawStat : rawStats) {
-            statMap.put(rawStat.getGameType(), rawStat);
-        }
+        LocalDate targetDate = LocalDate.parse(request.getTargetDate());
 
         List<StatisticsItemResponse> stats = List.of(
-                buildItem(GameType.WORD_MEMORY, statMap.get(GameType.WORD_MEMORY)),
-                buildItem(GameType.ARITHMETIC, statMap.get(GameType.ARITHMETIC)),
-                buildItem(GameType.DESCARTES_RPS, statMap.get(GameType.DESCARTES_RPS))
+                buildStatisticsItem(memberId, GameType.WORD_MEMORY, "기억력", targetDate),
+                buildStatisticsItem(memberId, GameType.ARITHMETIC, "계산력", targetDate),
+                buildStatisticsItem(memberId, GameType.DESCARTES_RPS, "판단력", targetDate)
         );
 
         return StatisticsResponse.builder()
@@ -55,58 +43,68 @@ public class StatisticsServiceImpl implements StatisticsService {
                 .build();
     }
 
-    private StatisticsItemResponse buildItem(GameType gameType, StatisticsItemResponse rawStat) {
-        if (rawStat == null) {
+    private StatisticsItemResponse buildStatisticsItem(
+            Long memberId,
+            GameType gameType,
+            String gameName,
+            LocalDate targetDate
+    ) {
+        List<RecentGameScore> recentGames =
+                statisticsMapper.findScoresByType(memberId, gameType, targetDate);
+
+        if (recentGames == null || recentGames.isEmpty()) {
             return StatisticsItemResponse.builder()
                     .gameType(gameType)
-                    .gameName(gameType.getDisplayName())
+                    .gameName(gameName)
                     .playCount(0)
                     .totalQuestions(0)
                     .totalCorrect(0)
                     .accuracy(null)
+                    .scores(Collections.emptyList())
                     .build();
+        }
+
+        // DB에서는 최신순으로 가져오므로, 오래된 순 -> 최신 순으로 뒤집기
+        Collections.reverse(recentGames);
+
+        int playCount = recentGames.size();
+        int totalQuestions = playCount * 3;
+        int totalCorrect = recentGames.stream()
+                .mapToInt(RecentGameScore::getCorrectCount)
+                .sum();
+
+        Integer accuracy = totalQuestions == 0
+                ? null
+                : (totalCorrect * 100) / totalQuestions;
+
+        List<Integer> scores = new ArrayList<>();
+        int cumulativeCorrect = 0;
+        int cumulativeQuestions = 0;
+
+        for (RecentGameScore game : recentGames) {
+            cumulativeCorrect += game.getCorrectCount();
+            cumulativeQuestions += 3;
+            scores.add((cumulativeCorrect * 100) / cumulativeQuestions);
         }
 
         return StatisticsItemResponse.builder()
                 .gameType(gameType)
-                .gameName(gameType.getDisplayName())
-                .playCount(defaultZero(rawStat.getPlayCount()))
-                .totalQuestions(defaultZero(rawStat.getTotalQuestions()))
-                .totalCorrect(defaultZero(rawStat.getTotalCorrect()))
-                .accuracy(rawStat.getAccuracy())
+                .gameName(gameName)
+                .playCount(playCount)
+                .totalQuestions(totalQuestions)
+                .totalCorrect(totalCorrect)
+                .accuracy(accuracy)
+                .scores(scores)
                 .build();
     }
 
-    private void validateMember(Long memberId) {
+    private void validateMemberExists(Long memberId) {
         if (memberId == null) {
             throw new BaseException(401, "로그인이 필요합니다.");
         }
 
-        Member member = memberMapper.findByMemberId(memberId);
-        if (member == null) {
-            throw new BaseException(404, "사용자 정보를 찾을 수 없습니다. 다시 로그인해 주세요.");
+        if (memberMapper.findByMemberId(memberId) == null) {
+            throw new BaseException(404, "사용자 정보를 찾을 수 없습니다.");
         }
-
-    }
-
-    private LocalDate parseTargetDate(String targetDate) {
-        try {
-            return LocalDate.parse(targetDate);
-        } catch (DateTimeParseException e) {
-            throw new BaseException(400, "잘못된 요청입니다. 입력값을 확인해주세요.");
-        }
-    }
-
-    private void validateNotFuture(LocalDate targetDate) {
-        LocalDate today = LocalDate.now();
-        if (targetDate.isAfter(today)) {
-            throw new BaseException(
-                    400, "미래의 날짜는 조회할 수 없습니다. 오늘 또는 과거의 날짜를 선택해주세요."
-            );
-        }
-    }
-
-    private int defaultZero(Integer value) {
-        return value == null ? 0 : value;
     }
 }

--- a/src/main/resources/mapper/GameStatisticsMapper.xml
+++ b/src/main/resources/mapper/GameStatisticsMapper.xml
@@ -5,60 +5,21 @@
 
 <mapper namespace="com.rememberme.dunoesanchaeg.statistics.mapper.StatisticsMapper">
 
-    <resultMap id="StatisticsItemResultMap"
-               type="com.rememberme.dunoesanchaeg.statistics.dto.response.StatisticsItemResponse">
-        <result property="gameType" column="game_type"/>
-        <result property="playCount" column="play_count"/>
-        <result property="totalQuestions" column="total_questions"/>
-        <result property="totalCorrect" column="total_correct"/>
-        <result property="accuracy" column="accuracy"/>
+    <resultMap id="recentGameScoreResultMap"
+               type="com.rememberme.dunoesanchaeg.statistics.domain.RecentGameScore">
+        <result property="correctCount" column="correct_count"/>
     </resultMap>
 
-    <select id="findStatistics" resultMap="StatisticsItemResultMap">
+    <select id="findScoresByType" resultMap="recentGameScoreResultMap">
         SELECT
-            game_type,
-            COUNT(*) AS play_count,
-            COALESCE(SUM(total_try_count), 0) AS total_questions,
-            COALESCE(SUM(correct_count), 0) AS total_correct,
-            CASE
-                WHEN COALESCE(SUM(total_try_count), 0) = 0 THEN NULL
-                ELSE FLOOR(SUM(correct_count) * 100 / SUM(total_try_count))
-                END AS accuracy
-        FROM (
-                 (
-                     SELECT game_type, total_try_count, correct_count
-                     FROM daily_game_log
-                     WHERE member_id = #{memberId}
-                       AND game_type = 'WORD_MEMORY'
-                       AND played_date &lt;= #{targetDate}
-                       AND is_valid = 1
-                     ORDER BY played_date DESC, created_at DESC, session_id DESC
-                         LIMIT 7
-                 )
-                 UNION ALL
-                 (
-                     SELECT game_type, total_try_count, correct_count
-                     FROM daily_game_log
-                     WHERE member_id = #{memberId}
-                       AND game_type = 'ARITHMETIC'
-                       AND played_date &lt;= #{targetDate}
-                       AND is_valid = 1
-                     ORDER BY played_date DESC, created_at DESC, session_id DESC
-                         LIMIT 7
-                 )
-                 UNION ALL
-                 (
-                     SELECT game_type, total_try_count, correct_count
-                     FROM daily_game_log
-                     WHERE member_id = #{memberId}
-                       AND game_type = 'DESCARTES_RPS'
-                       AND played_date &lt;= #{targetDate}
-                       AND is_valid = 1
-                     ORDER BY played_date DESC, created_at DESC, session_id DESC
-                         LIMIT 7
-                 )
-             ) AS recent_records
-        GROUP BY game_type
-        ORDER BY FIELD(game_type, 'WORD_MEMORY', 'ARITHMETIC', 'DESCARTES_RPS')
+            correct_count
+        FROM daily_game_log
+        WHERE member_id = #{memberId}
+          AND game_type = #{gameType}
+          AND played_date &lt;= #{targetDate}
+          AND is_valid = 1
+        ORDER BY played_date DESC, created_at DESC, session_id DESC
+            LIMIT 7
     </select>
+
 </mapper>


### PR DESCRIPTION
<!-- 제목 예시: [feat] 관리자 페이지 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->
 
## 🔎개요 
통계에서 그래프를 그리기 위해서 배열로 응답하기 위해 추가
 
 
<br/>
 
## 📝작업 내용
- target_date 기준으로 각 종목별 최근 7회 조회
- 7회의 각각의 점수 배열을 scores로 응답
- 동시에 그 7회의 총합 기준 정답률을 accuracy로 응답
 
 
<br/>
 
<img width="847" height="633" alt="image" src="https://github.com/user-attachments/assets/361018a8-43b9-4fe0-946a-92e4a1add90e" />
