### PR TITLE
fix: 미니게임 결과 저장 검증 로직 수정

### DIFF
--- a/src/main/java/com/rememberme/dunoesanchaeg/contents/service/CognitiveGameServiceImpl.java
+++ b/src/main/java/com/rememberme/dunoesanchaeg/contents/service/CognitiveGameServiceImpl.java
@@ -121,6 +121,10 @@ public class CognitiveGameServiceImpl implements CognitiveGameService {
             throw new BaseException(400, "게임 결과 값은 0 이상이어야 합니다.");
         }
 
+        if (request.getTotalTryCount() < 1) {
+            throw new BaseException(400, "총 시도 횟수는 최소 1회 이상이어야 합니다.");
+        }
+
         if (request.getCorrectCount() > TOTAL_ROUNDS ||
                 request.getTimeoutCount() > TOTAL_ROUNDS) {
             throw new BaseException(400, "정답 개수 또는 시간 초과 횟수가 총 판 수를 초과할 수 없습니다.");
@@ -130,8 +134,5 @@ public class CognitiveGameServiceImpl implements CognitiveGameService {
             throw new BaseException(400, "정답 개수와 시간 초과 횟수의 합은 3이어야 합니다.");
         }
 
-        if (request.getTotalPlayedTime() > TOTAL_ROUNDS * ROUND_TIME_LIMIT_SEC) {
-            throw new BaseException(400, "총 플레이 시간은 45초를 초과할 수 없습니다.");
-        }
     }
 }


### PR DESCRIPTION
* fix: 총 시도 횟수(`totalTryCount`)가 최소 1회 이상인지 검증하는 예외 처리 추가
* fix: 총 플레이 시간 45초 초과 검증 로직 제거
